### PR TITLE
replace deprecated template provider with templatefile function

### DIFF
--- a/dex.tf
+++ b/dex.tf
@@ -1,42 +1,19 @@
 # Create Dex
 
-data "template_file" "config_yaml" {
-  template = <<-EOT
-    issuer: http://dex.auth.svc.cluster.local:5556/dex
-    storage:
-      type: kubernetes
-      config:
-        inCluster: true
-    web:
-      http: 0.0.0.0:5556
-    logger:
-      level: "debug"
-      format: text
-    oauth2:
-      skipApprovalScreen: true
-    enablePasswordDB: true
-    staticPasswords:
-    - email: ${var.dex_user_email}
-      hash: ${var.dex_user_hash}
-      # https://github.com/dexidp/dex/pull/1601/commits
-      # FIXME: Use hashFromEnv instead
-      username: ${var.dex_user_name}
-      userID: "${var.dex_user_id}"
-    staticClients:
-    # https://github.com/dexidp/dex/pull/1664
-    - idEnv: OIDC_CLIENT_ID
-      redirectURIs: ["/login/oidc"]
-      name: 'Dex Login Application'
-      secretEnv: OIDC_CLIENT_SECRET
-  EOT
-}
-
 data "kustomization_overlay" "dex" {
   config_map_generator {
     name     = "dex"
     behavior = "merge"
     literals = [
-      "config.yaml=${data.template_file.config_yaml.rendered}"
+      "config.yaml=${templatefile(
+        "${path.module}/templates/dex_config_map_overlay.tftpl",
+        {
+          dex_user_email = var.dex_user_email,
+          dex_user_hash  = var.dex_user_hash,
+          dex_user_name  = var.dex_user_name,
+          dex_user_id    = var.dex_user_id,
+        }
+      )}"
     ]
   }
 

--- a/examples/kubernetes/main.tf
+++ b/examples/kubernetes/main.tf
@@ -2,7 +2,7 @@ terraform {
 }
 
 module "kubeflow" {
-  source = "WOGRA-AG/kubeflow/kustomization"
+  source = "../../"
 
   dex_user_email = "my@example.com"
 }

--- a/examples/kubernetes/main.tf
+++ b/examples/kubernetes/main.tf
@@ -4,5 +4,5 @@ terraform {
 module "kubeflow" {
   source = "../../"
 
-  dex_user_email = "my@example.com"
+  dex_user_email = "user@example.com"
 }

--- a/templates/dex_config_map_overlay.tftpl
+++ b/templates/dex_config_map_overlay.tftpl
@@ -1,0 +1,26 @@
+    issuer: http://dex.auth.svc.cluster.local:5556/dex
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    web:
+      http: 0.0.0.0:5556
+    logger:
+      level: "debug"
+      format: text
+    oauth2:
+      skipApprovalScreen: true
+    enablePasswordDB: true
+    staticPasswords:
+    - email: ${dex_user_email}
+      hash: ${dex_user_hash}
+      # https://github.com/dexidp/dex/pull/1601/commits
+      # FIXME: Use hashFromEnv instead
+      username: ${dex_user_name}
+      userID: "${dex_user_id}"
+    staticClients:
+    # https://github.com/dexidp/dex/pull/1664
+    - idEnv: OIDC_CLIENT_ID
+      redirectURIs: ["/login/oidc"]
+      name: 'Dex Login Application'
+      secretEnv: OIDC_CLIENT_SECRET

--- a/versions.tf
+++ b/versions.tf
@@ -12,10 +12,6 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.7.2"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">=2.2.0"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">=2.11.0"


### PR DESCRIPTION
replace deprecated template provider with templatefile function

The Template provider is [deprecated](https://registry.terraform.io/providers/hashicorp/template/latest/docs#deprecation) and also doesn't have MacOS M1 binaries, so usage of this module with the deprecated provider on a macOS M1 was not possible.

This pull request replaces the provider with the [templatefile function](https://www.terraform.io/language/functions/templatefile?_ga=2.182408803.595436734.1660422344-1881467886.1660422344#templatefile-function).

I also updated the example usage to point to the source of the module. This should make for a better local development / usage experience. 

